### PR TITLE
Fix mui code style

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,28 @@
     "extends": [
       "react-app",
       "plugin:prettier/recommended"
-    ]
+    ],
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "paths": [
+            {
+              "name": "@material-ui/core",
+              "message": "Import single components from the submodules instead."
+            },
+            {
+              "name": "@material-ui/icons",
+              "message": "Import single icons from submodules instead."
+            },
+            {
+              "name": "@material-ui/styles",
+              "message": "Import from @material-ui/core/styles instead."
+            }
+          ]
+        }
+      ]
+    }
   },
   "prettier": {
     "semi": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,8 @@ import { ApolloProvider as ApolloHooksProvider } from 'react-apollo-hooks';
 import { client } from './graphql/client';
 
 import 'typeface-roboto';
-import { makeStyles, ThemeProvider } from '@material-ui/styles';
-import { Theme, createStyles, CssBaseline } from '@material-ui/core';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { makeStyles, Theme, createStyles, MuiThemeProvider as ThemeProvider } from '@material-ui/core/styles';
 import theme from './theme';
 
 import { HomePage } from './pages/Home/HomePage';

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withRouter } from 'react-router';
-import { Box, Breadcrumbs as MaterialBreadcrumbs } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import MaterialBreadcrumbs from '@material-ui/core/Breadcrumbs';
 import { Home, Restaurant, AccountCircle } from '@material-ui/icons/';
 import { SvgIconProps } from '@material-ui/core/SvgIcon';
 

--- a/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { Typography, Link } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Link from '@material-ui/core/Link';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { SvgIconProps } from '@material-ui/core/SvgIcon';
 

--- a/src/components/Center.tsx
+++ b/src/components/Center.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
-import { Theme, createStyles } from '@material-ui/core';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/components/DrawerAndNavbar/Drawer.tsx
+++ b/src/components/DrawerAndNavbar/Drawer.tsx
@@ -1,8 +1,17 @@
 import React, { Fragment } from 'react';
-import { makeStyles, createStyles } from '@material-ui/styles';
-import { Theme } from '@material-ui/core/styles';
-import { Divider, List, Hidden, Drawer } from '@material-ui/core';
-import { Restaurant, ShoppingCart, AttachMoney, RestaurantMenu, Fastfood, School, Settings } from '@material-ui/icons/';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Divider from '@material-ui/core/Divider';
+import List from '@material-ui/core/List';
+import Hidden from '@material-ui/core/Hidden';
+import Drawer from '@material-ui/core/Drawer';
+
+import Restaurant from '@material-ui/icons/Restaurant';
+import ShoppingCart from '@material-ui/icons/ShoppingCart';
+import AttachMoney from '@material-ui/icons/AttachMoney';
+import RestaurantMenu from '@material-ui/icons/RestaurantMenu';
+import Fastfood from '@material-ui/icons/Fastfood';
+import School from '@material-ui/icons/School';
+import Settings from '@material-ui/icons/Settings';
 
 import { ToolbarSpacer } from '../ToolbarSpacer';
 import { DrawerListItem } from './DrawerListItem';

--- a/src/components/DrawerAndNavbar/DrawerListItem.tsx
+++ b/src/components/DrawerAndNavbar/DrawerListItem.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { withRouter, RouteComponentProps } from 'react-router';
 
-import { ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
 
 interface DrawerListItemProps {
   page: string;

--- a/src/components/DrawerAndNavbar/Navbar.tsx
+++ b/src/components/DrawerAndNavbar/Navbar.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Link as RouterLink } from 'react-router-dom';
-import { AppBar, Toolbar, Typography, Button, IconButton } from '@material-ui/core';
+
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+
 import MenuIcon from '@material-ui/icons/Menu';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 

--- a/src/components/ToolbarSpacer.tsx
+++ b/src/components/ToolbarSpacer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { makeStyles } from '@material-ui/styles';
-import { Theme, createStyles } from '@material-ui/core';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/graphql/client/link.ts
+++ b/src/graphql/client/link.ts
@@ -11,7 +11,7 @@ const httpLink = new HttpLink({
   credentials: 'same-origin',
 });
 
-const errorLink = onError(({ graphQLErrors, networkError, }) => {
+const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors) {
     graphQLErrors.forEach(({ message, locations, path, extensions }) => {
       console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`);

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+
 import { PageContainer } from '../../components/PageContainer';
 
 export const HomePage: React.FC = () => {

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -3,25 +3,27 @@ import { Redirect } from 'react-router';
 
 import Avatar from '@material-ui/core/Avatar';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
 
 import { useDoLoginMutation } from '../../generated/graphql';
 import { PageContainer } from '../../components/PageContainer';
 import { LoginForm } from './components/LoginForm';
 
-const useStyles = makeStyles(theme => ({
-  container: {
-    marginTop: theme.spacing(8),
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
-  avatar: {
-    margin: theme.spacing(1),
-    backgroundColor: theme.palette.secondary.main,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    container: {
+      marginTop: theme.spacing(8),
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+    },
+    avatar: {
+      margin: theme.spacing(1),
+      backgroundColor: theme.palette.secondary.main,
+    },
+  }),
+);
 
 export const LoginPage: React.FC = () => {
   const classes = useStyles();

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Redirect } from 'react-router';
-import { makeStyles, Avatar, Typography } from '@material-ui/core';
+
+import Avatar from '@material-ui/core/Avatar';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
 
 import { useDoLoginMutation } from '../../generated/graphql';

--- a/src/pages/Login/components/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import useForm from 'react-hook-form';
-import { TextField, FormControlLabel, Checkbox, makeStyles, Typography } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 
 import { LoadingButton } from '../../../components/LoadingButton';
 import { getErrorMessage } from '../../../util/form';

--- a/src/pages/Login/components/LoginForm.tsx
+++ b/src/pages/Login/components/LoginForm.tsx
@@ -4,20 +4,22 @@ import TextField from '@material-ui/core/TextField';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 
 import { LoadingButton } from '../../../components/LoadingButton';
 import { getErrorMessage } from '../../../util/form';
 
-const useStyles = makeStyles(theme => ({
-  form: {
-    width: '100%', // Fix IE 11 issue.
-    marginTop: theme.spacing(1),
-  },
-  submit: {
-    margin: theme.spacing(3, 0, 2),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    form: {
+      width: '100%', // Fix IE 11 issue.
+      marginTop: theme.spacing(1),
+    },
+    submit: {
+      margin: theme.spacing(3, 0, 2),
+    },
+  }),
+);
 
 const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 

--- a/src/pages/Shop/ShopPage.tsx
+++ b/src/pages/Shop/ShopPage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { CircularProgress, Typography, Button } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
 
 import { GetShopProductsComponent } from '../../generated/graphql';
 

--- a/src/pages/Shop/components/ProductCategorySublist.tsx
+++ b/src/pages/Shop/components/ProductCategorySublist.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ListSubheader, Typography } from '@material-ui/core';
+import ListSubheader from '@material-ui/core/ListSubheader';
+import Typography from '@material-ui/core/Typography';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) =>

--- a/src/pages/Shop/components/ProductList.tsx
+++ b/src/pages/Shop/components/ProductList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import groupBy from 'lodash.groupby';
-import { List } from '@material-ui/core';
+import List from '@material-ui/core/List';
 
 import { ProductCategory } from './ProductCategorySublist';
 import { ProductListItem } from './ProductListItem';

--- a/src/pages/Shop/components/ProductListItem.tsx
+++ b/src/pages/Shop/components/ProductListItem.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { ListItem, ListItemAvatar, Avatar, ListItemText, ListItemSecondaryAction, Typography } from '@material-ui/core';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import Avatar from '@material-ui/core/Avatar';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import Typography from '@material-ui/core/Typography';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 import { QuantityInput } from './QuantityInput';

--- a/src/pages/Shop/components/QuantityInput.tsx
+++ b/src/pages/Shop/components/QuantityInput.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { IconButton, Typography } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { AddShoppingCart, Add, Remove } from '@material-ui/icons';
+import AddShoppingCart from '@material-ui/icons/AddShoppingCart';
+import Add from '@material-ui/icons/Add';
+import Remove from '@material-ui/icons/Remove';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/pages/UserSettings/UserSettingsPage.tsx
+++ b/src/pages/UserSettings/UserSettingsPage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Typography, CircularProgress, Button } from '@material-ui/core';
-import { makeStyles } from '@material-ui/styles';
-import { Theme, createStyles } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Button from '@material-ui/core/Button';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 
 import { PageContainer } from '../../components/PageContainer';
 import { Center } from '../../components/Center';

--- a/src/pages/UserSettings/components/UpdatePasswordButton.tsx
+++ b/src/pages/UserSettings/components/UpdatePasswordButton.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import useForm from 'react-hook-form';
-import {
-  Button,
-  Dialog,
-  DialogTitle,
-  DialogContentText,
-  DialogContent,
-  DialogActions,
-  TextField,
-  Typography,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+
 import { getErrorMessage } from '../../../util/form';
 import { mapErrorToMessage } from '../../../util/graphql';
 import { useDoPasswordUpdateMutation } from '../../../generated/graphql';

--- a/src/pages/UserSettings/components/UserInfo.tsx
+++ b/src/pages/UserSettings/components/UserInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 
 interface UserInfoProps {
   userData: {


### PR DESCRIPTION
Changes
* Import single components and icons instead of importing from @material-ui/core or @material-ui/icons
* Added rules to ESLint to ensure that previous point is enforced going forwards
* Use `createStyles()` when creating styles