### PR TITLE
Fix: stop redicrect on page reload

### DIFF
--- a/src/components/LoggedInRoute.tsx
+++ b/src/components/LoggedInRoute.tsx
@@ -14,7 +14,7 @@ export const LoggedInRoute: React.FC<LoggedInRouteProps> = ({
   redirect = '/',
   ...rest
 }) => {
-  const { data } = useUserRoleQuery();
+  const { data } = useUserRoleQuery({ suspend: true });
   const isLoggedIn = !!(data && data.self);
   const canSee = loggedOut ? !isLoggedIn : isLoggedIn;
 


### PR DESCRIPTION
Fixed an issue when reloading the page you would be redirected to the shop page if logged in or home page if logged out.